### PR TITLE
fixed error about relative gen path

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -30,7 +30,7 @@ job=buildingblock-version:
   mounts:
     - mount-buildingblock-gitversion-source-dir
     - mount-buildingblock-gitversion-gen-dir
-  sources: "./"
-  artifact: "gen/gitversion/"
+  sources: "{fs.projectdir}"
+  artifact: "{fs.projectdir}/gen/gitversion/"
   env:
     - "USERID={user.uid}"


### PR DESCRIPTION
if dobi is called several times, the following error occurs: 
[ERROR] failed to execute task "buildingblock-version:": Rel: can't make gen/gitversion/ relative to /home/#/projects/techpo